### PR TITLE
Use nightly `1.75`

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -13,7 +13,7 @@ jobs:
           packages: lld
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: 1.72.0
+          toolchain: nightly-2023-10-28
       - uses: olix0r/cargo-action-fmt/setup@v2.0.1
       - run: cargo check -q --message-format=json | cargo-action-fmt
 
@@ -21,11 +21,11 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.6.0
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
           # we have to use nightly since come important options are not stable yet
-          toolchain: nightly
+          toolchain: nightly-2023-10-28
           components: rustfmt
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1.1.0
@@ -42,7 +42,7 @@ jobs:
           packages: lld
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: 1.72.0
+          toolchain: nightly-2023-10-28
           components: clippy
       - uses: auguwu/clippy-action@1.2.2
         with:
@@ -58,6 +58,6 @@ jobs:
           packages: lld
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: 1.72.0
+          toolchain: nightly-2023-10-28
       - uses: olix0r/cargo-action-fmt/setup@v2.0.1
       - run: cargo doc --no-deps --message-format=json | cargo-action-fmt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,5 +13,5 @@ jobs:
           packages: lld
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: 1.72.0
+          toolchain: nightly-2023-10-28
       - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,17 +76,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
-name = "async-trait"
-version = "0.1.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,7 +714,6 @@ dependencies = [
 name = "rjacraft_protocol"
 version = "0.0.1"
 dependencies = [
- "async-trait",
  "bytes",
  "from_never",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ bevy_ecs = "0.11"
 bevy_app = "0.11"
 
 # Async
-async-trait = "0.1"
 tokio = { version = "1.32", default-features = false }
 flume = "0.11"
 

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -17,6 +17,5 @@ bytes.workspace = true
 uuid.workspace = true
 from_never.workspace = true
 paste.workspace = true
-async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,5 +1,7 @@
 //! The crucial parts of Minecraft's protocol.
 
+use std::future::Future;
+
 use tokio::io;
 
 /// A packet or any part of a packet.
@@ -19,13 +21,14 @@ pub trait ProtocolType: Sized {
 
 /// Currently used by the networking code to read packet length prefixes.
 pub trait ProtocolTypeRaw: ProtocolType {
-    async fn decode_raw(
+    fn decode_raw(
         read: &mut (impl io::AsyncRead + Unpin + Send),
-    ) -> io::Result<Result<Self, Self::DecodeError>>;
-    async fn encode_raw(
+    ) -> impl Future<Output = io::Result<Result<Self, Self::DecodeError>>> + Send;
+
+    fn encode_raw(
         &self,
         write: &mut (impl io::AsyncWrite + Unpin + Send),
-    ) -> io::Result<Result<(), Self::EncodeError>>;
+    ) -> impl Future<Output = io::Result<Result<(), Self::EncodeError>>> + Send;
 }
 
 pub mod error;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -18,7 +18,6 @@ pub trait ProtocolType: Sized {
 }
 
 /// Currently used by the networking code to read packet length prefixes.
-#[async_trait::async_trait]
 pub trait ProtocolTypeRaw: ProtocolType {
     async fn decode_raw(
         read: &mut (impl io::AsyncRead + Unpin + Send),

--- a/crates/protocol/src/packets/c2s.rs
+++ b/crates/protocol/src/packets/c2s.rs
@@ -1,6 +1,6 @@
 //! Server-bound packets
 
-pub use self::{configuration::*, handshake::*, login::*, play::*, status::*};
+pub use self::{configuration::*, handshake::*, login::*, status::*};
 use crate::packets::prelude::*;
 
 mod configuration;

--- a/crates/protocol/src/types/varint.rs
+++ b/crates/protocol/src/types/varint.rs
@@ -76,7 +76,6 @@ impl ProtocolType for VarInt {
     }
 }
 
-#[async_trait::async_trait]
 impl ProtocolTypeRaw for VarInt {
     async fn decode_raw(
         read: &mut (impl io::AsyncRead + Unpin + Send),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-10-28"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# Description

This version stabilizes `async fn`s in traits thus we only use it as a preview of `1.75`.
Once this version is stable (December 28th), we will be able to bring back stable-by-default.
